### PR TITLE
Modified fuzzy type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,7 +36,7 @@ export declare interface SearchOptions {
   prefix?: boolean
     | ((term: string, index: number, terms: string[]) => boolean),
 
-  fuzzy?: boolean
+  fuzzy?: boolean | number 
     | ((term: string, index: number, terms: string[]) => boolean | number),
 
   combineWith?: string,


### PR DESCRIPTION
With Typescript, the compiler complies if we assign a numeric value to `fuzzy` parameter.  
I have modified the type definition in `src/index.d.ts` properly.