### PR TITLE
Fix typings for storeFields

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,8 +27,6 @@ declare class MiniSearch {
 export declare interface SearchOptions {
   fields?: string[],
 
-  storeFields?: string[],
-
   filter?: (result: SearchResult) => boolean,
 
   boost?: { [fieldName: string]: number },
@@ -50,6 +48,8 @@ export declare interface SearchOptions {
 
 export declare interface Options {
   fields: string[],
+
+  storeFields?: string[],
 
   idField?: string,
 


### PR DESCRIPTION
The `SearchOptions` interface has the typings for the `storeFields` property, which should be on the top-level `Options` interface.

This moves those declarations as per https://github.com/lucaong/minisearch/issues/27.