### PR TITLE
perf(minisearch): replaces `Object.keys` with `hasOwnProperty`

### DIFF
--- a/src/MiniSearch.js
+++ b/src/MiniSearch.js
@@ -464,8 +464,7 @@ class MiniSearch {
   * // => throws 'MiniSearch: unknown option "notExisting"'
   */
   static getDefault (optionName) {
-    const validKeys = Object.keys(defaultOptions)
-    if (validKeys.includes(optionName)) {
+    if (defaultOptions.hasOwnProperty(optionName)) {
       return defaultOptions[optionName]
     } else {
       throw new Error(`MiniSearch: unknown option "${optionName}"`)


### PR DESCRIPTION
Small performance improvement. 

I see that you do a lot of iterations over the same arrays, like `.map().filter().map()`. This is a potential place to improve performance if will be important someday