### PR TITLE
Implement removeAll method

### DIFF
--- a/src/MiniSearch.js
+++ b/src/MiniSearch.js
@@ -246,7 +246,7 @@ class MiniSearch {
   *   2. apply changes
   *   3. index new version
   *
-  * @param {Object} document - the document to be indexed
+  * @param {Object} document - the document to be removed
   */
   remove (document) {
     const { tokenize, processTerm, extractField, fields, idField } = this._options
@@ -276,6 +276,26 @@ class MiniSearch {
     delete this._storedFields[shortDocumentId]
     delete this._documentIds[shortDocumentId]
     this._documentCount -= 1
+  }
+
+  /**
+  * Removes all the given documents from the index. If called with no arguments,
+  * it removes _all_ documents from the index.
+  *
+  * @param {Array<Object>} [documents] - the documents to be removed
+  */
+  removeAll (documents) {
+    if (arguments.length === 0) {
+      this._index = new SearchableMap()
+      this._documentCount = 0
+      this._documentIds = {}
+      this._fieldLength = {}
+      this._averageFieldLength = {}
+      this._storedFields = {}
+      this._nextId = 0
+    } else {
+      documents.forEach(document => this.remove(document))
+    }
   }
 
   /**

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -255,6 +255,50 @@ describe('MiniSearch', () => {
     })
   })
 
+  describe('removeAll', () => {
+    const documents = [
+      { id: 1, title: 'Divina Commedia', text: 'Nel mezzo del cammin di nostra vita ... cammin' },
+      { id: 2, title: 'I Promessi Sposi', text: 'Quel ramo del lago di Como' },
+      { id: 3, title: 'Vita Nova', text: 'In quella parte del libro della mia memoria ... cammin' }
+    ]
+
+    let ms, _warn
+    beforeEach(() => {
+      ms = new MiniSearch({ fields: ['title', 'text'] })
+      _warn = console.warn
+      console.warn = jest.fn()
+    })
+
+    afterEach(() => {
+      console.warn = _warn
+    })
+
+    it('removes all documents from the index if called with no argument', () => {
+      const empty = MiniSearch.loadJSON(JSON.stringify(ms), {
+        fields: ['title', 'text']
+      })
+
+      ms.addAll(documents)
+      expect(ms.documentCount).toEqual(3)
+
+      ms.removeAll()
+
+      expect(ms).toEqual(empty)
+    })
+
+    it('removes the given documents from the index', () => {
+      ms.addAll(documents)
+      expect(ms.documentCount).toEqual(3)
+
+      ms.removeAll([documents[0], documents[2]])
+
+      expect(ms.documentCount).toEqual(1)
+      expect(ms.search('commedia').length).toEqual(0)
+      expect(ms.search('vita').length).toEqual(0)
+      expect(ms.search('lago').length).toEqual(1)
+    })
+  })
+
   describe('addAll', () => {
     it('adds all the documents to the index', () => {
       const ms = new MiniSearch({ fields: ['text'] })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,8 @@ declare class MiniSearch {
 
     remove(document: object): void;
 
+    removeAll(documents?: object[]): void;
+
     search(query: string, options?: SearchOptions): SearchResult[];
 
     toJSON(): object;


### PR DESCRIPTION
If called with a list of documents, it removes each of them.

If called with no arguments, it efficiently removes all documents from
the index.