### PR TITLE
Fix issues with terms or fields named like default properties of object

### DIFF
--- a/src/MiniSearch.js
+++ b/src/MiniSearch.js
@@ -180,7 +180,7 @@ class MiniSearch {
   */
   add (document) {
     const { extractField, tokenize, processTerm, fields, idField } = this._options
-    if (document[idField] == null) {
+    if (getOwnProperty(document, idField) == null) {
       throw new Error(`MiniSearch: document does not have ID field "${idField}"`)
     }
     const shortDocumentId = addDocumentId(this, document[idField])
@@ -254,7 +254,7 @@ class MiniSearch {
   remove (document) {
     const { tokenize, processTerm, extractField, fields, idField } = this._options
 
-    if (document[idField] == null) {
+    if (getOwnProperty(document, idField) == null) {
       throw new Error(`MiniSearch: document does not have ID field "${idField}"`)
     }
 
@@ -265,7 +265,7 @@ class MiniSearch {
       throw new Error(`MiniSearch: cannot remove document with ID ${document[idField]}: it is not in the index`)
     }
 
-    fields.filter(field => document[field] != null).forEach(field => {
+    fields.filter(field => getOwnProperty(document, field) != null).forEach(field => {
       const tokens = tokenize(extractField(document, field) || '', field)
 
       tokens.forEach(term => {
@@ -572,7 +572,7 @@ class MiniSearch {
     options = { ...this._options.searchOptions, ...options }
 
     const boosts = (options.fields || this._options.fields).reduce((boosts, field) =>
-      ({ ...boosts, [field]: boosts[field] || 1 }), options.boost || {})
+      ({ ...boosts, [field]: getOwnProperty(boosts, field) || 1 }), options.boost || {})
 
     const {
       boostDocument,

--- a/src/MiniSearch.js
+++ b/src/MiniSearch.js
@@ -710,12 +710,16 @@ const termResults = function (self, term, boosts, boostDocument, indexData, weig
       const normalizedLength = self._fieldLength[documentId][fieldId] / self._averageFieldLength[fieldId]
       results[documentId] = results[documentId] || { score: 0, match: {}, terms: [] }
       results[documentId].terms.push(term)
-      results[documentId].match[term] = results[documentId].match[term] || []
+      results[documentId].match[term] = getOwnProperty(results[documentId].match, term) || []
       results[documentId].score += docBoost * score(tf, df, self._documentCount, normalizedLength, boost, editDistance)
       results[documentId].match[term].push(field)
     })
     return results
   }, {})
+}
+
+const getOwnProperty = function (object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property) ? object[property] : undefined
 }
 
 const addFieldLength = function (self, documentId, fieldId, count, length) {

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -583,6 +583,22 @@ describe('MiniSearch', () => {
           expect(processTerm).toHaveBeenCalledWith(term)
         })
       })
+
+      it('does not break when special properties of object are used as a term', () => {
+        const specialWords = ['constructor', 'hasOwnProperty', 'isPrototypeOf']
+        const ms = new MiniSearch({ fields: ['text'] })
+        const processTerm = MiniSearch.getDefault('processTerm')
+
+        ms.add({ id: 1, text: specialWords.join(' ') })
+
+        specialWords.forEach((word) => {
+          expect(() => { ms.search(word) }).not.toThrowError()
+
+          const results = ms.search(word)
+          expect(results[0].id).toEqual(1)
+          expect(results[0].match[processTerm(word)]).toEqual(['text'])
+        })
+      })
     })
   })
 

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -40,6 +40,13 @@ describe('MiniSearch', () => {
       }).toThrowError('MiniSearch: document does not have ID field "foo"')
     })
 
+    it('throws error if the document does not have the ID field, even when named like a default object property', () => {
+      const ms = new MiniSearch({ idField: 'constructor', fields: ['title', 'text'] })
+      expect(() => {
+        ms.add({ text: 'I do not have an ID' })
+      }).toThrowError('MiniSearch: document does not have ID field "constructor"')
+    })
+
     it('rejects falsy terms', () => {
       const processTerm = term => term === 'foo' ? null : term
       const ms = new MiniSearch({ fields: ['title', 'text'], processTerm })
@@ -172,6 +179,23 @@ describe('MiniSearch', () => {
       expect(() => {
         ms.remove({ text: 'I do not have an ID' })
       }).toThrowError('MiniSearch: document does not have ID field "foo"')
+    })
+
+    it('throws error if the document does not have the ID field, even if named like a default property of object', () => {
+      const ms = new MiniSearch({ idField: 'constructor', fields: ['title', 'text'] })
+      expect(() => {
+        ms.remove({ text: 'I do not have an ID' })
+      }).toThrowError('MiniSearch: document does not have ID field "constructor"')
+    })
+
+    it('does not crash when the document has field named like default properties of object', () => {
+      const ms = new MiniSearch({ fields: ['constructor'] })
+      const document = { id: 1 }
+      ms.add(document)
+
+      expect(() => {
+        ms.remove(document)
+      }).not.toThrowError()
     })
 
     it('does not reassign IDs', () => {
@@ -421,6 +445,17 @@ describe('MiniSearch', () => {
       const results = ms.search('vita', { boost: { title: 2 } })
       expect(results.map(({ id }) => id)).toEqual([3, 1])
       expect(results[0].score).toBeGreaterThan(results[1].score)
+    })
+
+    it('computes a meaningful score when fields are named liked default properties of object', () => {
+      const ms = new MiniSearch({ fields: ['constructor'] })
+      ms.add({ id: 1, constructor: 'something' })
+      ms.add({ id: 1, constructor: 'something else' })
+
+      const results = ms.search('something')
+      results.forEach((result) => {
+        expect(Number.isFinite(result.score)).toBe(true)
+      })
     })
 
     it('searches in the given fields', () => {


### PR DESCRIPTION
In several places, it is necessary to access only the own properties of objects, to avoid issues caused by field names or terms corresponding to default properties of JavaScript objects.