### PR TITLE
Mark parameter to `MiniSearch.removeAll` as optional

### DIFF
--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -559,6 +559,8 @@ export default class MiniSearch<T = any> {
   removeAll (documents?: T[]): void {
     if (documents) {
       documents.forEach(document => this.remove(document))
+    } else if (arguments.length > 0) {
+      throw new Error('Expected documents to be present. Omit the argument to remove all documents.')
     } else {
       this._index = new SearchableMap()
       this._documentCount = 0

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -556,8 +556,10 @@ export default class MiniSearch<T = any> {
    * more efficient to call this method with no arguments than to pass all
    * documents.
    */
-  removeAll (documents: T[]): void {
-    if (arguments.length === 0) {
+  removeAll (documents?: T[]): void {
+    if (documents) {
+      documents.forEach(document => this.remove(document))
+    } else {
       this._index = new SearchableMap()
       this._documentCount = 0
       this._documentIds = {}
@@ -565,8 +567,6 @@ export default class MiniSearch<T = any> {
       this._averageFieldLength = {}
       this._storedFields = {}
       this._nextId = 0
-    } else {
-      documents.forEach(document => this.remove(document))
     }
   }
 


### PR DESCRIPTION
According to the documentation, `documents` is optional. However, with current typing it was not possible to call it without an argument.

I swapped the condition branches, because checking `arguments.length == 0` did not rule out `documents` being null/undefined, so `documents` needs to be checked explicitly, and `if (documents)` seems clearer to me here than `if (!documents)`.