### PR TITLE
[fix] Adjust field length data upon document removal

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -160,6 +160,19 @@ describe('MiniSearch', () => {
       expect(console.warn).not.toHaveBeenCalled()
     })
 
+    it('cleans up all data of the deleted document', () => {
+      const otherDocument = { id: 4, title: 'Decameron', text: 'Umana cosa è aver compassione degli afflitti' }
+      const originalFieldLength = JSON.parse(JSON.stringify(ms._fieldLength))
+      const originalAverageFieldLength = JSON.parse(JSON.stringify(ms._averageFieldLength))
+
+      ms.add(otherDocument)
+      ms.remove(otherDocument)
+
+      expect(ms.documentCount).toEqual(3)
+      expect(ms._fieldLength).toEqual(originalFieldLength)
+      expect(ms._averageFieldLength).toEqual(originalAverageFieldLength)
+    })
+
     it('does not remove terms from other documents', () => {
       ms.remove(documents[0])
       expect(ms.search('cammin').length).toEqual(1)

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -545,10 +545,13 @@ export default class MiniSearch<T = any> {
           this.removeTerm(this._fieldIds[field], shortDocumentId, processedTerm)
         }
       })
+
+      this.removeFieldLength(shortDocumentId, this._fieldIds[field], this.documentCount, tokens.length)
     })
 
     delete this._storedFields[shortDocumentId]
     delete this._documentIds[shortDocumentId]
+    delete this._fieldLength[shortDocumentId]
     this._documentCount -= 1
   }
 
@@ -1064,6 +1067,14 @@ export default class MiniSearch<T = any> {
     this._fieldLength[documentId] = this._fieldLength[documentId] || {}
     this._fieldLength[documentId][fieldId] = length
     this._averageFieldLength[fieldId] = totalLength / (count + 1)
+  }
+
+  /**
+   * @ignore
+   */
+  private removeFieldLength (documentId: string, fieldId: number, count: number, length: number): void {
+    const totalLength = (this._averageFieldLength[fieldId] * count) - length
+    this._averageFieldLength[fieldId] = totalLength / (count - 1)
   }
 
   /**


### PR DESCRIPTION
The data about field length and average field length needs to be
adjusted after removal of a document to reflect the change. This commit
takes care of that.