### PR TITLE
Performance increase

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -12,7 +12,7 @@ describe('MiniSearch', () => {
       const options = { fields: ['title', 'text'] }
       const ms = new MiniSearch(options)
       expect(ms._documentCount).toEqual(0)
-      expect(ms._fieldIds).toEqual(new Map(Object.entries({ title: 0, text: 1 })))
+      expect(ms._fieldIds).toEqual({ title: 0, text: 1 })
       expect(ms._documentIds.size).toEqual(0)
       expect(ms._fieldLength.size).toEqual(0)
       expect(ms._averageFieldLength.length).toEqual(0)
@@ -206,7 +206,7 @@ describe('MiniSearch', () => {
       ms.remove(documents[0])
       expect(ms._index.has('commedia')).toEqual(false)
       expect(ms._documentIds.size).toEqual(originalIdsSize - 1)
-      expect(Array.from(ms._index.get('vita').keys())).toEqual([ms._fieldIds.get('title')])
+      expect(Array.from(ms._index.get('vita').keys())).toEqual([ms._fieldIds.title])
     })
 
     it('throws error if the document does not have the ID field', () => {

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -12,10 +12,10 @@ describe('MiniSearch', () => {
       const options = { fields: ['title', 'text'] }
       const ms = new MiniSearch(options)
       expect(ms._documentCount).toEqual(0)
-      expect(ms._fieldIds).toEqual({ title: 0, text: 1 })
-      expect(ms._documentIds).toEqual({})
-      expect(ms._fieldLength).toEqual({})
-      expect(ms._averageFieldLength).toEqual({})
+      expect(ms._fieldIds).toEqual(new Map(Object.entries({ title: 0, text: 1 })))
+      expect(ms._documentIds.size).toEqual(0)
+      expect(ms._fieldLength.size).toEqual(0)
+      expect(ms._averageFieldLength.length).toEqual(0)
       expect(ms._options).toMatchObject(options)
     })
   })
@@ -162,8 +162,8 @@ describe('MiniSearch', () => {
 
     it('cleans up all data of the deleted document', () => {
       const otherDocument = { id: 4, title: 'Decameron', text: 'Umana cosa è aver compassione degli afflitti' }
-      const originalFieldLength = JSON.parse(JSON.stringify(ms._fieldLength))
-      const originalAverageFieldLength = JSON.parse(JSON.stringify(ms._averageFieldLength))
+      const originalFieldLength = new Map(ms._fieldLength)
+      const originalAverageFieldLength = ms._averageFieldLength.slice()
 
       ms.add(otherDocument)
       ms.remove(otherDocument)
@@ -202,11 +202,11 @@ describe('MiniSearch', () => {
     })
 
     it('cleans up the index', () => {
-      const originalIdsLength = Object.keys(ms._documentIds).length
+      const originalIdsSize = ms._documentIds.size
       ms.remove(documents[0])
       expect(ms._index.has('commedia')).toEqual(false)
-      expect(Object.keys(ms._documentIds).length).toEqual(originalIdsLength - 1)
-      expect(Object.keys(ms._index.get('vita'))).toEqual([ms._fieldIds.title.toString()])
+      expect(ms._documentIds.size).toEqual(originalIdsSize - 1)
+      expect(Array.from(ms._index.get('vita').keys())).toEqual([ms._fieldIds.get('title')])
     })
 
     it('throws error if the document does not have the ID field', () => {

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -345,7 +345,7 @@ export default class MiniSearch<T = any> {
   protected _index: SearchableMap
   protected _documentCount: number
   protected _documentIds: Map<number, any>
-  protected _fieldIds: Map<string, number>
+  protected _fieldIds: { [key: string]: number }
   protected _fieldLength: Map<number, number[]>
   protected _averageFieldLength: number[]
   protected _nextId: number
@@ -429,7 +429,11 @@ export default class MiniSearch<T = any> {
 
     this._documentIds = new Map()
 
-    this._fieldIds = new Map()
+    // Fields are defined during initialization, don't change, are few in
+    // number, rarely need iterating over, and have string keys. Therefore in
+    // this case an object is a better candidate than a Map to store the mapping
+    // from field key to ID.
+    this._fieldIds = {}
 
     this._fieldLength = new Map()
 
@@ -461,7 +465,7 @@ export default class MiniSearch<T = any> {
       if (fieldValue == null) continue
 
       const tokens = tokenize(fieldValue.toString(), field)
-      const fieldId = this._fieldIds.get(field)!
+      const fieldId = this._fieldIds[field]
 
       this.addFieldLength(shortDocumentId, fieldId, this.documentCount - 1, tokens.length)
 
@@ -543,7 +547,7 @@ export default class MiniSearch<T = any> {
           if (fieldValue == null) continue
 
           const tokens = tokenize(fieldValue.toString(), field)
-          const fieldId = this._fieldIds.get(field)!
+          const fieldId = this._fieldIds[field]
 
           for (const term of tokens) {
             const processedTerm = processTerm(term, field)
@@ -914,7 +918,7 @@ export default class MiniSearch<T = any> {
     miniSearch._documentCount = documentCount
     miniSearch._nextId = nextId
     miniSearch._documentIds = objectToNumericMap(documentIds)
-    miniSearch._fieldIds = objectToMap(fieldIds)
+    miniSearch._fieldIds = fieldIds
     miniSearch._fieldLength = objectToNumericMap(fieldLength)
     miniSearch._averageFieldLength = averageFieldLength
     miniSearch._storedFields = objectToNumericMap(storedFields)
@@ -1036,7 +1040,7 @@ export default class MiniSearch<T = any> {
       documentCount: this._documentCount,
       nextId: this._nextId,
       documentIds: Object.fromEntries(this._documentIds),
-      fieldIds: Object.fromEntries(this._fieldIds),
+      fieldIds: this._fieldIds,
       fieldLength: Object.fromEntries(this._fieldLength),
       averageFieldLength: this._averageFieldLength,
       storedFields: Object.fromEntries(this._storedFields)
@@ -1060,7 +1064,7 @@ export default class MiniSearch<T = any> {
 
     for (const field of Object.keys(boosts)) {
       const boost = boosts[field]
-      const fieldId = this._fieldIds.get(field)!
+      const fieldId = this._fieldIds[field]
       const entry = indexData.get(fieldId)
       if (entry == null) continue
 
@@ -1142,8 +1146,8 @@ export default class MiniSearch<T = any> {
    */
   private warnDocumentChanged (shortDocumentId: number, fieldId: number, term: string): void {
     if (console == null || console.warn == null) { return }
-    for (const [fieldName, id] of this._fieldIds) {
-      if (id === fieldId) {
+    for (const fieldName of Object.keys(this._fieldIds)) {
+      if (this._fieldIds[fieldName] === fieldId) {
         console.warn(`MiniSearch: document with ID ${this._documentIds.get(shortDocumentId)} has changed before removal: term "${term}" was not present in field "${fieldName}". Removing a document after it has changed can corrupt the index!`)
         return
       }
@@ -1166,7 +1170,7 @@ export default class MiniSearch<T = any> {
    */
   private addFields (fields: string[]): void {
     for (let i = 0; i < fields.length; i++) {
-      this._fieldIds.set(fields[i], i)
+      this._fieldIds[fields[i]] = i
     }
   }
 
@@ -1301,16 +1305,6 @@ const defaultAutoSuggestOptions = {
 }
 
 const createMap = () => new Map()
-
-const objectToMap = <T>(object: { [key: string]: T }): Map<string, T> => {
-  const map = new Map()
-
-  for (const key of Object.keys(object)) {
-    map.set(key, object[key])
-  }
-
-  return map
-}
 
 type TreeLikeObject<T = any> = { [key: string]: TreeLikeObject | T }
 type SerializedIndexEntry = { df: number, ds: { [key: string]: number } }

--- a/src/SearchableMap/SearchableMap.test.js
+++ b/src/SearchableMap/SearchableMap.test.js
@@ -59,7 +59,7 @@ describe('SearchableMap', () => {
       const map = new SearchableMap()
 
       map.set('hello', 1)
-      const before = JSON.parse(JSON.stringify(map))
+      const before = new SearchableMap(new Map(map._tree))
 
       map.set('help', 2)
       map.delete('help')

--- a/src/SearchableMap/SearchableMap.ts
+++ b/src/SearchableMap/SearchableMap.ts
@@ -227,6 +227,10 @@ export default class SearchableMap<T = any> {
    * searchableMap.update('somekey', (currentValue) => currentValue == null ? 0 : currentValue + 1)
    * ```
    *
+   * If the value at the given key is or will be an object, it might not require
+   * re-assignment. In that case it is better to use `fetch()`, because it is
+   * faster.
+   *
    * @param key  The key to update
    * @param fn  The function used to compute the new value from the current one
    * @return The [[SearchableMap]] itself, to allow chaining

--- a/src/SearchableMap/SearchableMap.ts
+++ b/src/SearchableMap/SearchableMap.ts
@@ -118,7 +118,6 @@ export default class SearchableMap<T = any> {
   /**
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach
    * @param fn  Iteration function
-   * @deprecated Use a `for (... of ...)` loop instead.
    */
   forEach (fn: (key: string, value: T, map: SearchableMap) => void): void {
     for (const [key, value] of this) {

--- a/src/SearchableMap/TreeIterator.ts
+++ b/src/SearchableMap/TreeIterator.ts
@@ -34,7 +34,7 @@ class TreeIterator<T, V> implements Iterator<V> {
 
   constructor (set: IterableSet<T>, type: IteratorType) {
     const node = set._tree
-    const keys = Object.keys(node)
+    const keys = Array.from(node.keys())
     this.set = set
     this._type = type
     this._path = keys.length > 0 ? [{ node, keys }] : []
@@ -50,7 +50,7 @@ class TreeIterator<T, V> implements Iterator<V> {
     if (this._path.length === 0) { return { done: true, value: undefined } }
     const { node, keys } = last(this._path)!
     if (last(keys) === LEAF) { return { done: false, value: this.result() as V } }
-    this._path.push({ node: node[last(keys)!] as RadixTree<T>, keys: Object.keys(node[last(keys)!]) })
+    this._path.push({ node: node.get(last(keys)!) as RadixTree<T>, keys: Array.from((node.get(last(keys)!) as RadixTree<T>).keys()) })
     return this.dive()
   }
 
@@ -70,7 +70,7 @@ class TreeIterator<T, V> implements Iterator<V> {
   }
 
   value (): T {
-    return last(this._path)!.node[LEAF] as T
+    return last(this._path)!.node.get(LEAF) as T
   }
 
   result (): unknown {

--- a/src/SearchableMap/fuzzySearch.ts
+++ b/src/SearchableMap/fuzzySearch.ts
@@ -38,19 +38,19 @@ export const fuzzySearch = <T = any>(node: RadixTree<T>, query: string, maxDista
   while (stack.length > 0) {
     const { node, distance, key, i, edit } = stack.pop()!
 
-    Object.keys(node).forEach((k) => {
+    for (const k of node.keys()) {
       if (k === LEAF) {
         const totDistance = distance + (query.length - i)
         const [, d] = results[key] || [null, Infinity]
         if (totDistance <= maxDistance && totDistance < d) {
-          results[key] = [node[k] as T, totDistance]
+          results[key] = [node.get(k) as T, totDistance]
         }
       } else {
         withinDistance(query, k, maxDistance - distance, i, edit, innerStack).forEach(({ distance: d, i, edit }) => {
-          stack.push({ node: node[k] as RadixTree<T>, distance: distance + d, key: key + k, i, edit })
+          stack.push({ node: node.get(k) as RadixTree<T>, distance: distance + d, key: key + k, i, edit })
         })
       }
-    })
+    }
   }
   return results
 }

--- a/src/SearchableMap/types.ts
+++ b/src/SearchableMap/types.ts
@@ -1,6 +1,4 @@
-export type RadixTree<T> = {
-  [key: string]: RadixTree<T> | T
-}
+export type RadixTree<T> = Map<string, T | RadixTree<T>>;
 
 export type Entry<T> = [string, T]
 


### PR DESCRIPTION
Hi there!

First of all thanks for creating this library. We are using it in production on a website with published guidelines on hazardous substances, created in collaboration between ministries and other government bodies in The Netherlands.

Although we've been quite happy with the performance (great job!), our profiling shows that there is some improvement to be made with regards to the creation of temporary objects. This is mostly due to using plain objects instead of ES6 [Maps](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map). 

Objects are great for storing a fixed number of keys, but less great for a larger number of keys, for addition/deletion, or for iterating over them.

In particular the following pattern showed up in a few places:

```
Object.entries(object).forEach(([key, value]) => {
  //
})
```

This has some issues:
* It causes at least one allocation for the array returned by `Object.entries()`.
* It probably causes an allocation for the closure passed into `forEach()`.
* Iterating with `for ... of ... ` is almost always faster (in part due to the allocations).
* Unnecessary temporary objects cause pressure on the garbage collector.

I made the following changes:
* Most occurrences of objects are replaced with Maps.
* Functions that take closures are mostly replaced with loops.
* Some duplicate read/write operations were prevented.
* The internal IDs of fields are now numbers. Because field IDs are consecutive and do not change, we can store the field data in arrays with the ID as the index.
* Document short IDs are now numbers. There is no need to transform them into strings, which saves a small amount of space and time during indexing.

All of this mostly gave a performance boost. Using the benchmarks in the project on my laptop with Node v17.2.0 (which should be representative for a modern version of Chrome):
* Indexing is at least 4x faster.
* Combined search is about 2x faster.

However, **nothing comes for free**... Because the internal structure is no longer 1-1 serialisable to and from JSON, that operation becomes more expensive. Loading an index from JSON is about 30% **slower**, and is also much more complicated. The index format is also slightly different, so the serialised JSON is **not compatible** with the current version (and you might want to consider a major or minor version bump if you accept this PR).

ES6 Maps might also not be supported in very old browsers. However, their support is slightly better than that of Unicode Regexes, which are also used in the project.

Finally, I sacrificed some of your beautiful functional code style on the performance altar.

I'd love to hear your thoughts on this PR. Let me know if there is anything I should clarify!

### Before
```
Index size: 13497 terms, 14097 documents, ~17.49MB in memory, 2.37MB serialized.

Fuzzy search:
=============
  * SearchableMap#fuzzyGet("virtute", 1) x 24,029 ops/sec ±0.23% (100 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 2) x 1,918 ops/sec ±0.23% (99 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 3) x 385 ops/sec ±0.42% (95 runs sampled)

Prefix search:
==============
  * Array.from(SearchableMap#atPrefix("vir")) x 381,810 ops/sec ±0.13% (100 runs sampled)
  * Array.from(SearchableMap#atPrefix("virtut")) x 592,633 ops/sec ±0.16% (98 runs sampled)

Exact search:
=============
  * SearchableMap#get("virtute") x 858,585 ops/sec ±0.08% (99 runs sampled)

Indexing:
=========
  * MiniSearch#addAll(documents) x 3.76 ops/sec ±3.47% (14 runs sampled)

Combined search:
================
  * MiniSearch#search("virtute e conoscienza") x 46.38 ops/sec ±4.34% (63 runs sampled)

Search filtering:
=================
  * MiniSearch#search("virtu", { filter: ... }) x 9,135 ops/sec ±4.19% (88 runs sampled)

Auto suggestion:
================
  * MiniSearch#autoSuggest("virtute cano") x 33,132 ops/sec ±3.56% (91 runs sampled)
  * MiniSearch#autoSuggest("virtue conoscienza", { fuzzy: 0.2 }) x 181,194 ops/sec ±1.20% (101 runs sampled)

Load index:
===========
  * MiniSearch.loadJSON(json, options) x 33.50 ops/sec ±2.46% (60 runs sampled)
```

### After
```
Index size: 13497 terms, 14097 documents, ~16.01MB in memory, 2.49MB serialized.

Fuzzy search:
=============
  * SearchableMap#fuzzyGet("virtute", 1) x 27,119 ops/sec ±0.19% (99 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 2) x 2,253 ops/sec ±0.21% (99 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 3) x 434 ops/sec ±0.38% (92 runs sampled)

Prefix search:
==============
  * Array.from(SearchableMap#atPrefix("vir")) x 446,460 ops/sec ±0.22% (101 runs sampled)
  * Array.from(SearchableMap#atPrefix("virtut")) x 988,842 ops/sec ±0.27% (100 runs sampled)

Exact search:
=============
  * SearchableMap#get("virtute") x 1,823,572 ops/sec ±0.33% (94 runs sampled)

Indexing:
=========
  * MiniSearch#addAll(documents) x 12.09 ops/sec ±2.44% (35 runs sampled)

Combined search:
================
  * MiniSearch#search("virtute e conoscienza") x 91.87 ops/sec ±3.24% (69 runs sampled)

Search filtering:
=================
  * MiniSearch#search("virtu", { filter: ... }) x 18,009 ops/sec ±2.99% (83 runs sampled)

Auto suggestion:
================
  * MiniSearch#autoSuggest("virtute cano") x 58,476 ops/sec ±2.87% (87 runs sampled)
  * MiniSearch#autoSuggest("virtue conoscienza", { fuzzy: 0.2 }) x 327,262 ops/sec ±1.24% (98 runs sampled)

Load index:
===========
  * MiniSearch.loadJSON(json, options) x 23.24 ops/sec ±3.82% (43 runs sampled)
```
