### PR TITLE
Introduce max fuzziness for relative fuzziness values

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -550,6 +550,12 @@ describe('MiniSearch', () => {
       expect(results.map(({ id }) => id)).toEqual([1, 3])
     })
 
+    it('executes fuzzy search with maximum fuzziness', () => {
+      const results = ms.search('comedia', { fuzzy: 0.6, maxFuzziness: 3 })
+      expect(results.length).toEqual(1)
+      expect(results.map(({ id }) => id)).toEqual([1])
+    })
+
     it('executes prefix search', () => {
       const results = ms.search('que', { prefix: true })
       expect(results.length).toEqual(2)

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -551,7 +551,7 @@ describe('MiniSearch', () => {
     })
 
     it('executes fuzzy search with maximum fuzziness', () => {
-      const results = ms.search('comedia', { fuzzy: 0.6, maxFuzziness: 3 })
+      const results = ms.search('comedia', { fuzzy: 0.6, maxFuzzy: 3 })
       expect(results.length).toEqual(1)
       expect(results.map(({ id }) => id)).toEqual([1])
     })

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -84,7 +84,7 @@ export type SearchOptions = {
    * set to 6 by default. Very high edit distances usually don't produce
    * meaningful results, but can excessively impact search performance.
    */
-  maxFuzziness?: number,
+  maxFuzzy?: number,
 
   /**
    * The operand to combine partial results for each term. By default it is
@@ -116,7 +116,7 @@ type SearchOptionsWithDefaults = SearchOptions & {
 
   fuzzy: boolean | number | ((term: string, index: number, terms: string[]) => boolean | number),
 
-  maxFuzziness: number,
+  maxFuzzy: number,
 
   combineWith: string
 }
@@ -967,7 +967,7 @@ export default class MiniSearch<T = any> {
     const {
       boostDocument,
       weights,
-      maxFuzziness
+      maxFuzzy
     } = options
 
     const { fuzzy: fuzzyWeight, prefix: prefixWeight } = { ...defaultSearchOptions.weights, ...weights }
@@ -987,7 +987,7 @@ export default class MiniSearch<T = any> {
 
     if (query.fuzzy) {
       const fuzzy = (query.fuzzy === true) ? 0.2 : query.fuzzy
-      const maxDistance = fuzzy < 1 ? Math.min(maxFuzziness, Math.round(query.term.length * fuzzy)) : fuzzy
+      const maxDistance = fuzzy < 1 ? Math.min(maxFuzzy, Math.round(query.term.length * fuzzy)) : fuzzy
 
       Object.entries(this._index.fuzzyGet(query.term, maxDistance)).forEach(([term, [data, distance]]) => {
         const weightedDistance = distance / term.length
@@ -1264,7 +1264,7 @@ const defaultSearchOptions = {
   combineWith: OR,
   prefix: false,
   fuzzy: false,
-  maxFuzziness: 6,
+  maxFuzzy: 6,
   boost: {},
   weights: { fuzzy: 0.9, prefix: 0.75 }
 }

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -63,12 +63,14 @@ export type SearchOptions = {
    * performed if true.
    *
    * If a number higher or equal to 1 is given, fuzzy search is performed, with
-   * a mazimum edit distance (Levenshtein) equal to the number.
+   * a maximum edit distance (Levenshtein) equal to the number.
    *
    * If a number between 0 and 1 is given, fuzzy search is performed within a
    * maximum edit distance corresponding to that fraction of the term length,
    * approximated to the nearest integer. For example, 0.2 would mean an edit
    * distance of 20% of the term length, so 1 character in a 5-characters term.
+   * The calculated fuzziness value is limited by the `maxFuzzy` option, to
+   * prevent slowdown for very long queries.
    *
    * If a function is passed, the function is called upon search with a search
    * term, a positional index of that term in the tokenized search query, and
@@ -76,6 +78,13 @@ export type SearchOptions = {
    * the meaning documented above.
    */
   fuzzy?: boolean | number | ((term: string, index: number, terms: string[]) => boolean | number),
+
+  /**
+   * Controls the maximum fuzziness when using a fractional fuzzy value. This is
+   * set to 6 by default. Very high edit distances usually don't produce
+   * meaningful results, but can excessively impact search performance.
+   */
+  maxFuzziness?: number,
 
   /**
    * The operand to combine partial results for each term. By default it is
@@ -106,6 +115,8 @@ type SearchOptionsWithDefaults = SearchOptions & {
   prefix: boolean | ((term: string, index: number, terms: string[]) => boolean),
 
   fuzzy: boolean | number | ((term: string, index: number, terms: string[]) => boolean | number),
+
+  maxFuzziness: number,
 
   combineWith: string
 }
@@ -955,7 +966,8 @@ export default class MiniSearch<T = any> {
 
     const {
       boostDocument,
-      weights
+      weights,
+      maxFuzziness
     } = options
 
     const { fuzzy: fuzzyWeight, prefix: prefixWeight } = { ...defaultSearchOptions.weights, ...weights }
@@ -975,7 +987,7 @@ export default class MiniSearch<T = any> {
 
     if (query.fuzzy) {
       const fuzzy = (query.fuzzy === true) ? 0.2 : query.fuzzy
-      const maxDistance = fuzzy < 1 ? Math.round(query.term.length * fuzzy) : fuzzy
+      const maxDistance = fuzzy < 1 ? Math.min(maxFuzziness, Math.round(query.term.length * fuzzy)) : fuzzy
 
       Object.entries(this._index.fuzzyGet(query.term, maxDistance)).forEach(([term, [data, distance]]) => {
         const weightedDistance = distance / term.length
@@ -1252,6 +1264,7 @@ const defaultSearchOptions = {
   combineWith: OR,
   prefix: false,
   fuzzy: false,
+  maxFuzziness: 6,
   boost: {},
   weights: { fuzzy: 0.9, prefix: 0.75 }
 }


### PR DESCRIPTION
A footgun of the fractional `fuzzy` option (fuzziness set below 1), is that performance suffers for very long search terms. Although it is unlikely to be a critical problem for most real searches, this can be an issue for monkeys typing random characters on the keyboard, people testing search functionality, and the occasional user that types very long and specific technical words.

As we start approaching 30-40 characters with fuzziness set to `0.2` (as suggested in the documentation), the max edit distance that is used is starting to become so large as to be barely useful. This PR introduces a fuzziness maximum, set by default to 6. It is used only when setting a fractional fuzziness value. And it is configurable for someone who finds anything above that meaningful. Of course you can provide a custom fuzziness function, but it might be nice to protect users of this library against the issue by default?

An alternative could be to use a non-linear fuzziness function instead. Let me know what you think!