### PR TITLE
Fuzzy search performance

### DIFF
--- a/src/SearchableMap/SearchableMap.test.js
+++ b/src/SearchableMap/SearchableMap.test.js
@@ -253,7 +253,7 @@ describe('SearchableMap', () => {
     const map = SearchableMap.from(keyValues)
 
     it('returns all entries having the given maximum edit distance from the given key', () => {
-      [1, 2, 3].forEach(distance => {
+      [0, 1, 2, 3].forEach(distance => {
         const results = map.fuzzyGet('acqua', distance)
         const entries = Object.entries(results)
         expect(entries.map(([key, [value, dist]]) => [key, dist]).sort())


### PR DESCRIPTION
I was nerd-sniped by your [comment](https://github.com/lucaong/minisearch/pull/122#issuecomment-1041318324) regarding fuzzy search performance.

You're right that the algorithm you linked is faster. Performance is still not spectacular, but the improvement is significant. 

~This PR is based on #122; I can rebase when that is merged.~ Done

### Before
```
Fuzzy search:
=============
  * SearchableMap#fuzzyGet("virtute", 1) x 27,570 ops/sec ±0.16% (101 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 2) x 2,273 ops/sec ±0.34% (100 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 3) x 438 ops/sec ±0.42% (94 runs sampled)
```

### After
```
Fuzzy search:
=============
  * SearchableMap#fuzzyGet("virtute", 1) x 41,600 ops/sec ±0.24% (96 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 2) x 6,387 ops/sec ±0.20% (98 runs sampled)
  * SearchableMap#fuzzyGet("virtu", 3) x 1,736 ops/sec ±0.31% (98 runs sampled)
```