### PR TITLE
Fix the weights option

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -568,6 +568,19 @@ describe('MiniSearch', () => {
       expect(results.map(({ id }) => id)).toEqual([2, 1, 3])
     })
 
+    it('assigns weights to prefix matches and fuzzy matches', () => {
+      const exact = ms.search('cammino quel')
+      expect(exact.map(({ id }) => id)).toEqual([2])
+
+      const prefixLast = ms.search('cammino quel', { fuzzy: true, prefix: true, weights: { prefix: 0.1 } })
+      expect(prefixLast.map(({ id }) => id)).toEqual([2, 1, 3])
+      expect(prefixLast[0].score).toEqual(exact[0].score)
+
+      const fuzzyLast = ms.search('cammino quel', { fuzzy: true, prefix: true, weights: { fuzzy: 0.1 } })
+      expect(fuzzyLast.map(({ id }) => id)).toEqual([2, 3, 1])
+      expect(fuzzyLast[0].score).toEqual(exact[0].score)
+    })
+
     it('accepts a function to compute fuzzy and prefix options from term', () => {
       const fuzzy = jest.fn(term => term.length > 4 ? 2 : false)
       const prefix = jest.fn(term => term.length > 4)


### PR DESCRIPTION
The `weights` option allows users to provide the ability to override the relative scoring of fuzzy and prefix matches. However, due to a small bug they do not actually do anything. This PR addresses that. 

The reason this was overlooked until now is probably because both fuzzy and prefix matches _also_ include exact matches. This means an exact match is scored higher because it occurs in all matches. But it also means additional, needless work combining the scoring for matches that are found in the set of exact, fuzzy and prefix matches.

What I have done:
* Use the weight adjustments for scoring fuzzy and prefix matches and added tests to ensure this works.
* Remove exact matches from the (intermediate) fuzzy and prefix matches. This additional check easily pays for itself because of the reduction in the amount of work combining the results later. See the benchmarks at the end.
* Adjust the default weights down to somewhat correct for the removal of exact matches from the intermediate fuzzy and prefix results. I halved them to `{ fuzzy: 0.45, prefix: 0.375 }`. I am not 100% sure these weights are adequate, I'd like to get some input. It will be hard to guarantee identical search results, because the relative weight of exact matches currently is different depending on whether a user is using either fuzzy **or** prefix matching, versus fuzzy **and** prefix matching.
* Add a test to ensure the scoring of exact matches is not influenced by fuzzy or prefix matching.

~The PR is based on #122, and I can rebase when it is merged.~ Done

### Before
```
Combined search:
================
  * MiniSearch#search("virtute e conoscienza") x 95.29 ops/sec ±3.14% (71 runs sampled)
```

### After
```
Combined search:
================
  * MiniSearch#search("virtute e conoscienza") x 163 ops/sec ±2.93% (78 runs sampled)
```