### PR TITLE
Update design doc and reduce fuzzy search computations a bit

### DIFF
--- a/benchmarks/fuzzySearch.js
+++ b/benchmarks/fuzzySearch.js
@@ -8,6 +8,8 @@ suite.add('SearchableMap#fuzzyGet("virtute", 1)', () => {
   index.fuzzyGet('virtu', 2)
 }).add('SearchableMap#fuzzyGet("virtu", 3)', () => {
   index.fuzzyGet('virtu', 3)
+}).add('SearchableMap#fuzzyGet("virtute", 4)', () => {
+  index.fuzzyGet('virtute', 4)
 })
 
 export default suite

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1013,7 +1013,7 @@ export default class MiniSearch<T = any> {
     if (query.fuzzy) {
       const fuzzy = (query.fuzzy === true) ? 0.2 : query.fuzzy
       const maxDistance = fuzzy < 1 ? Math.min(maxFuzzy, Math.round(query.term.length * fuzzy)) : fuzzy
-      fuzzyMatches = this._index.fuzzyGet(query.term, maxDistance)
+      if (maxDistance) fuzzyMatches = this._index.fuzzyGet(query.term, maxDistance)
     }
 
     if (prefixMatches) {

--- a/src/SearchableMap/SearchableMap.test.js
+++ b/src/SearchableMap/SearchableMap.test.js
@@ -265,6 +265,11 @@ describe('SearchableMap', () => {
     it('returns an empty object if no matching entries are found', () => {
       expect(map.fuzzyGet('winter', 1)).toEqual(new Map())
     })
+
+    it('returns entries if edit distance is longer than key', () => {
+      const map = SearchableMap.from([['x', 1], [' x', 2]])
+      expect(Array.from(map.fuzzyGet('x', 2).values())).toEqual([[1, 0], [2, 1]])
+    })
   })
 
   describe('with generated test data', () => {


### PR DESCRIPTION
I updated the design doc to incorporate the changes from #125. While researching the algorithm I also encountered an optimisation (only calculate a diagonal band of size `2 * edit distance + 1`) that yields another modest performance improvement.