### PR TITLE
Improve TypeScript types

### DIFF
--- a/src/SearchableMap/fuzzySearch.ts
+++ b/src/SearchableMap/fuzzySearch.ts
@@ -71,7 +71,7 @@ const recurse = <T = any>(
       // store the result if it is.
       const distance = matrix[offset - 1]
       if (distance <= maxDistance) {
-        results.set(prefix, [node.get(key) as T, distance])
+        results.set(prefix, [node.get(key)!, distance])
       }
     } else {
       // Iterate over all characters in the key. Update the Levenshtein matrix
@@ -114,7 +114,7 @@ const recurse = <T = any>(
       }
 
       recurse(
-        node.get(key) as RadixTree<T>,
+        node.get(key)!,
         query,
         maxDistance,
         results,

--- a/src/SearchableMap/types.ts
+++ b/src/SearchableMap/types.ts
@@ -1,4 +1,12 @@
-export type RadixTree<T> = Map<string, T | RadixTree<T>>;
+export type LeafType = '' & { readonly __tag: unique symbol }
+
+export interface RadixTree<T> extends Map<string, T | RadixTree<T>> {
+  get(key: LeafType): T | undefined
+  get(key: string): RadixTree<T> | undefined
+
+  set(key: LeafType, value: T): this
+  set(key: string, value: RadixTree<T>): this
+}
 
 export type Entry<T> = [string, T]
 

--- a/src/SearchableMap/types.ts
+++ b/src/SearchableMap/types.ts
@@ -1,6 +1,9 @@
 export type LeafType = '' & { readonly __tag: unique symbol }
 
 export interface RadixTree<T> extends Map<string, T | RadixTree<T>> {
+  // Distinguish between an empty string indicating a leaf node and a non-empty
+  // string indicating a subtree. Overriding these types avoids a lot of type
+  // assertions elsewhere in the code.
   get(key: LeafType): T | undefined
   get(key: string): RadixTree<T> | undefined
 

--- a/src/SearchableMap/types.ts
+++ b/src/SearchableMap/types.ts
@@ -3,7 +3,9 @@ export type LeafType = '' & { readonly __tag: unique symbol }
 export interface RadixTree<T> extends Map<string, T | RadixTree<T>> {
   // Distinguish between an empty string indicating a leaf node and a non-empty
   // string indicating a subtree. Overriding these types avoids a lot of type
-  // assertions elsewhere in the code.
+  // assertions elsewhere in the code. It is not 100% foolproof because you can
+  // still pass in a blank string '' disguised as `string` and potentially get a
+  // leaf value.
   get(key: LeafType): T | undefined
   get(key: string): RadixTree<T> | undefined
 


### PR DESCRIPTION
OK, I swear I'll leave you alone after this...

This PR introduces a new unique type alias for the empty string that is used as 'Leaf' type. This allows relying on TypeScript whether a node contains a subtree or a value, and therefore a lot of type assertions can be removed. It also improves the types for the TreeIterator a bit. Just a some small type usability issues that I noticed when working on the rest of the code.