### PR TITLE
Make prefix match score higher than fuzzy (all else being equal)

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -598,6 +598,19 @@ describe('MiniSearch', () => {
       expect(combined[1].match.gentes).toEqual(['text'])
     })
 
+    it('ranks prefix matches higher than fuzzy matches with the same distance, all else being equal', () => {
+      const ms = new MiniSearch({ fields: ['text'] })
+      const documents = [
+        { id: 1, text: 'unicorns' },
+        { id: 2, text: 'unikorn' }
+      ]
+      ms.addAll(documents)
+      expect(ms.documentCount).toEqual(documents.length)
+
+      const results = ms.search('unicorn', { fuzzy: 0.2, prefix: true })
+      expect(results.map(({ id }) => id)).toEqual([1, 2])
+    })
+
     it('accepts a function to compute fuzzy and prefix options from term', () => {
       const fuzzy = jest.fn(term => term.length > 4 ? 2 : false)
       const prefix = jest.fn(term => term.length > 4)

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1396,7 +1396,7 @@ const defaultSearchOptions = {
   fuzzy: false,
   maxFuzzy: 6,
   boost: {},
-  weights: { fuzzy: 0.45, prefix: 0.375 }
+  weights: { fuzzy: 0.4, prefix: 0.375 }
 }
 
 const defaultAutoSuggestOptions = {


### PR DESCRIPTION
Addresses [this comment](https://github.com/lucaong/minisearch/issues/142#issuecomment-1088494160) regarding the relative ranking of prefix matches and fuzzy matches in `v5.0.0`.