### PR TITLE
Default to combineWith: AND in autoSuggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
-# v5.0.0-beta2
+# v5.0.0-beta3
 
 This is a beta release of `v5.0.0`. The main change is an improved scoring
 algorithm. The beta is generally stable, but the improvements to the scoring
@@ -16,6 +16,13 @@ issue](https://github.com/lucaong/minisearch/issues/142).
     results, improving their quality over the previous implementation. Note
     that, if you were using field boosting, you might need to re-adjust the
     boosting amounts, since their effect is now different.
+
+  - [breaking change] auto suggestions now default to `combineWith: 'AND'`
+    instead of `'OR'`, requiring all the query terms to match. The old defaults
+    can be replicated by passing a new `autoSuggestOptions` option to the
+    constructor, with value `{ autoSuggestOptions: { combineWith: 'OR' } }`.
+
+  - Possibility to set the default auto suggest options in the constructor.
 
   - Remove redundant fields in the index data. This also changes the
     serialization format, but serialized indexes created with `v4.x.y` are still

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1098,7 +1098,7 @@ e forse del mio dir poco ti cale`
 
     it('respects the order of the terms in the query', () => {
       const results = ms.autoSuggest('nostra vi')
-      expect(results.map(({ suggestion }) => suggestion)).toEqual(['nostra vita', 'vita'])
+      expect(results.map(({ suggestion }) => suggestion)).toEqual(['nostra vita'])
     })
 
     it('returns empty suggestions for terms that are not in the index', () => {
@@ -1127,6 +1127,26 @@ e forse del mio dir poco ti cale`
       })
       expect(results[0].suggestion).toEqual('quella')
       expect(results).toHaveLength(1)
+    })
+
+    it('respects the custom defaults set in the constructor', () => {
+      const ms = new MiniSearch({
+        fields: ['title', 'text'],
+        autoSuggestOptions: { combineWith: 'OR', fuzzy: true }
+      })
+      ms.addAll(documents)
+      const results = ms.autoSuggest('nosta vi')
+      expect(results.map(({ suggestion }) => suggestion)).toEqual(['nostra vita', 'vita'])
+    })
+
+    it('applies the default search options if not overridden by the auto suggest defaults', () => {
+      const ms = new MiniSearch({
+        fields: ['title', 'text'],
+        searchOptions: { combineWith: 'OR', fuzzy: true }
+      })
+      ms.addAll(documents)
+      const results = ms.autoSuggest('nosta vi')
+      expect(results.map(({ suggestion }) => suggestion)).toEqual(['nostra vita'])
     })
   })
 


### PR DESCRIPTION
The new default produces results that are usually more expected.

In addition, it is now possible to set the defaults in the constructor,
by passing a new `autoSuggestOptions` option. For example, to restore
the old defaults, one can set:

```javascript
const miniSearch = new MiniSearch({
  fields: [/* ... */],
  autoSuggestOptions: { combineWith: 'AND' }
})
```

See also the relevant discussion in https://github.com/lucaong/minisearch/issues/157