### PR TITLE
Allow processTerm to expand a single term into several ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+# v5.1.0 (unreleased)
+
+  - The `processTerm` option can now also expand a single term into several
+    terms by returning an array of strings.
+
 # v5.0.0
 
 This is a major release. The main change is an improved scoring algorithm based

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -130,6 +130,16 @@ describe('MiniSearch', () => {
         expect(processTerm).toHaveBeenCalledWith(term, 'title')
       })
     })
+
+    it('allows processTerm to expand a single term into several terms', () => {
+      const processTerm = (string) => string === 'foobar' ? ['foo', 'bar'] : string
+      const ms = new MiniSearch({ fields: ['title', 'text'], processTerm })
+      expect(() => {
+        ms.add({ id: 123, text: 'foobar' })
+      }).not.toThrowError()
+
+      expect(ms.search('bar')).toHaveLength(1)
+    })
   })
 
   describe('remove', () => {
@@ -257,6 +267,18 @@ describe('MiniSearch', () => {
       expect(() => {
         ms.remove(document)
       }).not.toThrowError()
+    })
+
+    it('allows processTerm to expand a single term into several terms', () => {
+      const processTerm = (string) => string === 'foobar' ? ['foo', 'bar'] : string
+      const ms = new MiniSearch({ fields: ['title', 'text'], processTerm })
+      const document = { id: 123, title: 'foobar' }
+      ms.add(document)
+      expect(() => {
+        ms.remove(document)
+      }).not.toThrowError()
+
+      expect(ms.search('bar')).toHaveLength(0)
     })
 
     describe('when using custom per-field extraction/tokenizer/processing', () => {
@@ -647,6 +669,13 @@ describe('MiniSearch', () => {
     it('rejects falsy terms', () => {
       const processTerm = (term) => term === 'quel' ? null : term
       const results = ms.search('quel commedia', { processTerm })
+      expect(results.length).toBeGreaterThan(0)
+      expect(results.map(({ id }) => id).sort()).toEqual([1])
+    })
+
+    it('allows processTerm to expand a single term into several terms', () => {
+      const processTerm = (string) => string === 'divinacommedia' ? ['divina', 'commedia'] : string
+      const results = ms.search('divinacommedia', { processTerm })
       expect(results.length).toBeGreaterThan(0)
       expect(results.map(({ id }) => id).sort()).toEqual([1])
     })


### PR DESCRIPTION
This is useful for normalizing a single term into several terms.

## Use case:

In a hypothetical music search application, the band name `"AC/DC"` would be tokenized by default as the terms `["ac", "dc"]`. A user might reasonably search for `"ACDC"`, which would be tokenized as `"acdc"`, and would therefore not match `"AC/DC"`.

Before this pull request, attempts to normalize the search query with `processTerm` to solve this issue would not work, because the term `"ACDC"` could only be normalized to a single term, while `["ac", "dc"]` are two separate terms. One could devise a solution using a custom tokenizer, but that is not where such normalization logic should belong.

This pull request allows `processTerm` to return an array of terms, normalizing a single term into more than one (it is still possible to return the processed term as a single string, as well as returning a falsy value to drop the term, making this change additive and backward compatible). With this change, one could solve the `"AC/DC"` issue by specifying a `processTerm` function that, when given the term `"ACDC"`, returns the array `["ac", "dc"]`, making the queries `"AC/DC"` and `"ACDC"` equivalent.