### PR TITLE
Add logger option to specify a custom logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
   - The `processTerm` option can now also expand a single term into several
     terms by returning an array of strings.
+  - Add `logger` option to pass a custom logger function.
 
 # v5.0.0
 

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -360,6 +360,16 @@ describe('MiniSearch', () => {
         expect(() => ms.remove({ id: 1, title: 'Divina Commedia cammin', text: 'something has changed' }))
           .not.toThrow()
       })
+
+      it('calls the custom logger if given', () => {
+        const logger = jest.fn()
+        ms = new MiniSearch({ fields: ['title', 'text'], logger })
+        ms.addAll(documents)
+        ms.remove({ id: 1, title: 'Divina Commedia', text: 'something' })
+
+        expect(logger).toHaveBeenCalledWith('warn', 'MiniSearch: document with ID 1 has changed before removal: term "something" was not present in field "text". Removing a document after it has changed can corrupt the index!', 'version_conflict')
+        expect(console.warn).not.toHaveBeenCalled()
+      })
     })
   })
 


### PR DESCRIPTION
Resolves #176 

This is useful for cases where `console` is not defined, or to handle specific log or warn messages (e.g. the warnings of document version conflicts upon calling `remove` with a modified document).