### PR TITLE
Add addFields method

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -759,6 +759,32 @@ describe('MiniSearch', () => {
     })
   })
 
+  describe('addFields', () => {
+    it('add fields to an existing document', () => {
+      const options = { fields: ['text', 'author'], storeFields: ['text', 'author', 'n'] }
+      const ms = new MiniSearch(options)
+      const other = new MiniSearch(options)
+
+      ms.add({ id: 1, text: 'Some quite interesting stuff' })
+      ms.addFields(1, { author: 'Al et. al.', n: 5 })
+
+      other.add({ id: 1, text: 'Some quite interesting stuff', author: 'Al et. al.', n: 5 })
+
+      expect(ms).toEqual(other)
+    })
+
+    it('throws an error if the document did not exist', () => {
+      const ms = new MiniSearch({ fields: ['text'] })
+      expect(() => { ms.addFields(1, { text: 'hello' }) }).toThrow('MiniSearch: no document with ID 1')
+    })
+
+    it('throws an error if adding a field that already exists', () => {
+      const ms = new MiniSearch({ fields: ['text'] })
+      ms.add({ id: 1, text: 'Some interesting stuff' })
+      expect(() => { ms.addFields(1, { text: 'hello' }) }).toThrow('MiniSearch: field text already exists on document with ID 1')
+    })
+  })
+
   describe('vacuum', () => {
     it('cleans up discarded documents from the index', async () => {
       const ms = new MiniSearch({ fields: ['text'], storeFields: ['text'] })


### PR DESCRIPTION
This method adds fields to an existing document. The fields should not exist already on the document, or an error is thrown.

This is useful to patch an existing document with some additional field, without having to replace it.

## Example:

```javascript
const miniSearch = new MiniSearch({ fields: ['title', 'text', 'author'] })
   
miniSearch.add({ id: 1, title: 'Neuromancer' })
   
miniSearch.addFields(1, {
  text: 'The sky above the port was the color of television, tuned to a dead channel.',
  author: 'William Gibson'
})
   
// The above is equivalent to:
miniSearch.add({
  id: 1,
  title: 'Neuromancer',
  text: 'The sky above the port was the color of television, tuned to a dead channel.',
  author: 'William Gibson'
})
```