### PR TITLE
Fix unwanted side effects of boost, and cascading of combineWith

### DIFF
--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1420,7 +1420,7 @@ export default class MiniSearch<T = any> {
     if (typeof query !== 'string') {
       const options = { ...searchOptions, ...query, queries: undefined }
       const results = query.queries.map((subquery) => this.executeQuery(subquery, options))
-      return this.combineResults(results, query.combineWith)
+      return this.combineResults(results, options.combineWith)
     }
 
     const { tokenize, processTerm, searchOptions: globalSearchOptions } = this._options
@@ -1442,7 +1442,7 @@ export default class MiniSearch<T = any> {
     const options: SearchOptionsWithDefaults = { ...this._options.searchOptions, ...searchOptions }
 
     const boosts = (options.fields || this._options.fields).reduce((boosts, field) =>
-      ({ ...boosts, [field]: getOwnProperty(boosts, field) || 1 }), options.boost || {})
+      ({ ...boosts, [field]: getOwnProperty(options.boost, field) || 1 }), {})
 
     const {
       boostDocument,


### PR DESCRIPTION
The `boost` search option was mistakenly causing boosted fields to be included in search, even when they were not in the `fields` search option.

The `combineWith` search option was not properly taking its default from the `SearchOptions` argument when using `search` with a `QuerySpec` tree.

Both issues are fixed by this commit, that also adds corresponding tests.

Resolves: #199 