### PR TITLE
Pass stored fields to boostDocument callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+# unreleased
+
+  - Pass stored fields to the `boostDocument` callback function, making it
+    easier to perform dynamic document boosting.
+
 # v6.0.1
 
   - [fix] The `boost` search option now does not interfere with the `fields`

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1109,14 +1109,15 @@ describe('MiniSearch', () => {
       expect(results.map(({ id }) => id)).toEqual([2, 1])
     })
 
-    it('boosts documents by calling boostDocument with document ID and term', () => {
-      const query = 'divina commedia'
+    it('boosts documents by calling boostDocument with document ID, term, and stored fields', () => {
+      const query = 'divina commedia nova'
       const boostFactor = 1.234
       const boostDocument = jest.fn((id, term) => boostFactor)
       const resultsWithoutBoost = ms.search(query)
       const results = ms.search(query, { boostDocument })
-      expect(boostDocument).toHaveBeenCalledWith(1, 'divina')
-      expect(boostDocument).toHaveBeenCalledWith(1, 'commedia')
+      expect(boostDocument).toHaveBeenCalledWith(1, 'divina', {})
+      expect(boostDocument).toHaveBeenCalledWith(1, 'commedia', {})
+      expect(boostDocument).toHaveBeenCalledWith(3, 'nova', { category: 'poetry' })
       expect(results[0].score).toBeCloseTo(resultsWithoutBoost[0].score * boostFactor)
     })
 


### PR DESCRIPTION
This makes it more convenient to perform dynamic document boosting:

```javascript
const documents = [
  {
    id: 1,
    text: 'Some example text',
    boostFactor: 1.5
  },
  {
    id: 2,
    text: 'Some other example text',
    boostFactor: 0.9
  },
  {
    id: 3,
    text: 'Some more example text',
    boostFactor: null
  }
]

// Initialize MiniSearch specifying storeFields
const miniSearch = new MiniSearch({
  fields: ['text'],
  storeFields: ['boostFactor']
})

// Upon search, use the `boostDocument` search option to specify a dynamic boosting factor on the basis of a stored field:
miniSearch.search('example', {
  boostDocument: (_docId, _term, storedFields) => storedFields.boostFactor || 1
})
```