### PR TITLE
Wildcard query that matches all documents

### DIFF
--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1241,6 +1241,14 @@ export default class MiniSearch<T = any> {
       }
     }
 
+    // If it's a wildcard query, and no document boost is applied, skip sorting
+    // the results, as all results have the same score of 1
+    if (query === MiniSearch.wildcard &&
+      searchOptions.boostDocument == null &&
+      this._options.searchOptions.boostDocument == null) {
+      return results
+    }
+
     results.sort(byScore)
     return results
   }


### PR DESCRIPTION
This pull request introduces a special wildcard value, `MiniSearch.wildcard`, that matches all documents:

```javascript
// Return search results for all documents
minisearch.search(MiniSearch.wildcard)

// Return search results for all documents in the 'fiction' category
minisearch.search(MiniSearch.wildcard, {
  filter: (result) => result.category === 'fiction'
})
```

This is useful for retrieving all results, but still apply search options such as `filter` and `boostDocument`. It can also be useful in query combinations, for example to query for all documents that DO NOT contain a specific term:

```javascript
// Search for all documents that do NOT contain the term "maintenance"
const results = ms.search({
  combineWith: 'AND_NOT',
  queries: [
    MiniSearch.wildcard,
    'maintenance'
  ]
})
```