### PR TITLE
improve TypeScript typings

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1298,7 +1298,7 @@ describe('MiniSearch', () => {
       })
 
       it('uses the search options in the second argument as default', () => {
-        let reference = ms.search({
+        const reference = ms.search({
           queries: [
             { fields: ['text'], queries: ['vita'] },
             { fields: ['title'], queries: ['promessi'] }

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -111,7 +111,7 @@ describe('MiniSearch', () => {
       expect(extractField).toHaveBeenCalledWith(document, 'title')
       expect(extractField).toHaveBeenCalledWith(document, 'pubDate')
       expect(extractField).toHaveBeenCalledWith(document, 'author.name')
-      expect(extractField).toHaveBeenCalledWith(document, 'category')
+      expect(extractField).not.toHaveBeenCalledWith(document, 'category')
       expect(tokenize).toHaveBeenCalledWith(document.title, 'title')
       expect(tokenize).toHaveBeenCalledWith(document.pubDate.toLocaleDateString('it-IT'), 'pubDate')
       expect(tokenize).toHaveBeenCalledWith(document.author.name, 'author.name')
@@ -1888,7 +1888,6 @@ e forse del mio dir poco ti cale`
       expect(MiniSearch.getDefault('tokenize')).toBeInstanceOf(Function)
       expect(MiniSearch.getDefault('processTerm')).toBeInstanceOf(Function)
       expect(MiniSearch.getDefault('searchOptions')).toBe(undefined)
-      expect(MiniSearch.getDefault('fields')).toBe(undefined)
     })
 
     it('throws an error if there is no option with the given name', () => {

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1,4 +1,5 @@
 import SearchableMap from './SearchableMap/SearchableMap'
+import type { Path } from './types'
 
 export type LowercaseCombinationOperator = 'or' | 'and' | 'and_not'
 export type CombinationOperator = LowercaseCombinationOperator | Uppercase<LowercaseCombinationOperator> | Capitalize<LowercaseCombinationOperator>
@@ -182,7 +183,7 @@ interface BaseOptions<T extends {}, SF extends string & keyof T> {
    /**
     * Names of the document fields to be indexed.
     */
-  fields: Array<string & keyof T>,
+  fields: Array<Path<T>>,
 
    /**
     * Names of fields to store, so that search results would include them. By

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -302,7 +302,7 @@ interface OptionsDefaultIdField<T extends {id: unknown}, SF extends string & key
   /**
     * Name of the ID field, uniquely identifying a document.
     */
-  idField?: "id";
+  idField?: 'id';
 }
 
 interface OptionsCustomIdField<T extends {}, SF extends string & keyof T = never> extends BaseOptions<T, SF> {
@@ -662,7 +662,7 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
       autoVacuum,
       searchOptions: { ...defaultSearchOptions, ...(options.searchOptions || {}) },
       autoSuggestOptions: { ...defaultAutoSuggestOptions, ...(options.autoSuggestOptions || {}) }
-    } as OptionsWithDefaults<T, SF>;
+    } as OptionsWithDefaults<T, SF>
 
     this._index = new SearchableMap()
 
@@ -1315,9 +1315,9 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
    * @param query  Search query
    * @param options  Search options. Each option, if not given, defaults to the corresponding value of `searchOptions` given to the constructor, or to the library default.
    */
-  search (query: Query<T, SF>, searchOptions: SearchOptions<T, SF> = {}): Array<SearchResult<T, SF>>  {
+  search (query: Query<T, SF>, searchOptions: SearchOptions<T, SF> = {}): Array<SearchResult<T, SF>> {
     const rawResults = this.executeQuery(query, searchOptions)
-    const results = [] as Array<SearchResult<T, SF>>;
+    const results = [] as Array<SearchResult<T, SF>>
 
     for (const [docId, { score, terms, match }] of rawResults) {
       // terms are the matched query terms, which will be returned to the user
@@ -1334,7 +1334,7 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
         match
       }
 
-      const result = Object.assign(partialResult, this._storedFields.get(docId)) as SearchResult<T, SF>;
+      const result = Object.assign(partialResult, this._storedFields.get(docId)) as SearchResult<T, SF>
       if (searchOptions.filter == null || searchOptions.filter(result)) {
         results.push(result)
       }
@@ -1569,7 +1569,7 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
   /**
    * @ignore
    */
-  private executeQuery (query: Query<T,SF>, searchOptions: SearchOptions<T,SF> = {}): RawResult {
+  private executeQuery (query: Query<T, SF>, searchOptions: SearchOptions<T, SF> = {}): RawResult {
     if (query === MiniSearch.wildcard) {
       return this.executeWildcardQuery(searchOptions)
     }
@@ -1595,8 +1595,8 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
   /**
    * @ignore
    */
-  private executeQuerySpec (query: QuerySpec, searchOptions: SearchOptions<T,SF>): RawResult {
-    const options: SearchOptionsWithDefaults<T,SF> = { ...this._options.searchOptions, ...searchOptions }
+  private executeQuerySpec (query: QuerySpec, searchOptions: SearchOptions<T, SF>): RawResult {
+    const options: SearchOptionsWithDefaults<T, SF> = { ...this._options.searchOptions, ...searchOptions }
 
     const boosts = (options.fields || this._options.fields).reduce((boosts, field) =>
       ({ ...boosts, [field]: getOwnProperty(options.boost, field) || 1 }), {} as Record<string & keyof T, number>)
@@ -1663,9 +1663,9 @@ export default class MiniSearch<T extends {}, SF extends string & keyof T = neve
   /**
    * @ignore
    */
-  private executeWildcardQuery (searchOptions: SearchOptions<T,SF>): RawResult {
+  private executeWildcardQuery (searchOptions: SearchOptions<T, SF>): RawResult {
     const results = new Map() as RawResult
-    const options: SearchOptionsWithDefaults<T,SF> = { ...this._options.searchOptions, ...searchOptions }
+    const options: SearchOptionsWithDefaults<T, SF> = { ...this._options.searchOptions, ...searchOptions }
 
     for (const [shortId, id] of this._documentIds) {
       const score = options.boostDocument ? options.boostDocument(id, '', this._storedFields.get(shortId)) : 1
@@ -2046,7 +2046,7 @@ const termToQuerySpec = (options: SearchOptions<any, any>) => (term: string, i: 
   return { term, fuzzy, prefix }
 }
 
-const defaultOptions: Omit<OptionsDefaultIdField<{id: any, [key: string]: any}>, "fields"> = {
+const defaultOptions: Omit<OptionsDefaultIdField<{id: any, [key: string]: any}>, 'fields'> = {
   idField: 'id',
   extractField: (document: any, fieldName: string) => document[fieldName],
   tokenize: (text: string) => text.split(SPACE_OR_PUNCTUATION),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,31 @@
+// https://www.calebpitan.com/blog/dot-notation-type-accessor-in-typescript#update-19th-march-2023-an-elaborate-deepprops-type
+
+type IsAny<T> = unknown extends T
+  ? [keyof T] extends [never]
+    ? false
+    : true
+  : false;
+
+type ExcludeArrayKeys<T> = T extends ArrayLike<any>
+  ? Exclude<keyof T, keyof any[]>
+  : keyof T;
+
+type PathImpl<T, Key extends keyof T> = Key extends string
+  ? IsAny<T[Key]> extends true
+    ? never
+    : T[Key] extends Record<string, any>
+    ?
+        | `${Key}.${PathImpl<T[Key], ExcludeArrayKeys<T[Key]>> & string}`
+        | `${Key}.${ExcludeArrayKeys<T[Key]> & string}`
+    : never
+  : never;
+
+type PathImpl2<T> = PathImpl<T, keyof T> | keyof T;
+
+export type Path<T> = keyof T extends string
+  ? PathImpl2<T> extends infer P
+    ? P extends string | keyof T
+      ? P
+      : keyof T
+    : keyof T
+  : never;


### PR DESCRIPTION
This alters the TypeScript typings to make it clear that the `fields`, `idField`, and `storeFields` properties must be keys in the document type. It also improves the typing of the `SearchResult` type so that it knows to combine it with the stored fields, and preserves the type information when doing so.

Now, in order to use this project with TypeScript, here is an example of the right way to do so:

```ts
interface Doc {
  id: number;
  title: string;
  pubDate: Date;
  author: { name: string };
  category: string;
}

const ms = new MiniSearch<Doc, 'title' | 'category'>({
  // Typescript can autocomplete field names, and even suggest deep paths like `author.name`!
  fields: ['title', 'pubDate', 'author.name'],
   // note that the `storeFields` are repeated in the type annotation
  storeFields: ['title', 'category'],
})
const document: Doc = {
  id: 1,
  title: 'Divina Commedia',
  pubDate: new Date(1320, 0, 1),
  author: { name: 'Dante Alighieri' },
  category: 'poetry'
}
ms.add(document)

const results = ms.search('Dante')
results[0].category  // Typescript understands that the `category` field is included in the results!
```
