### PR TITLE
Async load json

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1881,6 +1881,26 @@ e forse del mio dir poco ti cale`
     })
   })
 
+  describe('loadJSONAsync', () => {
+    const documents = [
+      { id: 1, title: 'Divina Commedia', text: 'Nel mezzo del cammin di nostra vita', category: 'poetry' },
+      { id: 2, title: 'I Promessi Sposi', text: 'Quel ramo del lago di Como', category: 'fiction' },
+      { id: 3, title: 'Vita Nova', text: 'In quella parte del libro della mia memoria', category: 'poetry' }
+    ]
+
+    it('makes a MiniSearch instance that is identical to .loadJSON()', async () => {
+      const options = { fields: ['title', 'text'], storeFields: ['category'] }
+      const ms = new MiniSearch(options)
+      ms.addAll(documents)
+      const json = JSON.stringify(ms)
+
+      const deserializedAsync = await MiniSearch.loadJSONAsync(json, options)
+      const deserialized = MiniSearch.loadJSON(json, options)
+
+      expect(deserialized).toEqual(deserializedAsync)
+    })
+  })
+
   describe('getDefault', () => {
     it('returns the default value of the given option', () => {
       expect(MiniSearch.getDefault('idField')).toEqual('id')

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1473,6 +1473,13 @@ export default class MiniSearch<T = any> {
     return this.loadJS(JSON.parse(json), options)
   }
 
+  /**
+   * Async equivalent of {@link MiniSearch.loadJSON}
+   *
+   * @param json  JSON-serialized index
+   * @param options  configuration options, same as the constructor
+   * @return A Promise that will resolve to an instance of MiniSearch deserialized from the given JSON.
+   */
   static async loadJSONAsync<T = any> (json: string, options: Options<T>): Promise<MiniSearch<T>> {
     if (options == null) {
       throw new Error('MiniSearch: loadJSON should be given the same options used when serializing the index')

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1515,32 +1515,17 @@ export default class MiniSearch<T = any> {
   static loadJS<T = any> (js: AsPlainObject, options: Options<T>): MiniSearch<T> {
     const {
       index,
-      documentCount,
-      nextId,
       documentIds,
-      fieldIds,
       fieldLength,
-      averageFieldLength,
       storedFields,
-      dirtCount,
       serializationVersion
     } = js
-    if (serializationVersion !== 1 && serializationVersion !== 2) {
-      throw new Error('MiniSearch: cannot deserialize an index created with an incompatible version')
-    }
 
-    const miniSearch = new MiniSearch(options)
+    const miniSearch = this.instantiateMiniSearch(js, options)
 
-    miniSearch._documentCount = documentCount
-    miniSearch._nextId = nextId
     miniSearch._documentIds = objectToNumericMap(documentIds)
-    miniSearch._idToShortId = new Map<any, number>()
-    miniSearch._fieldIds = fieldIds
     miniSearch._fieldLength = objectToNumericMap(fieldLength)
-    miniSearch._avgFieldLength = averageFieldLength
     miniSearch._storedFields = objectToNumericMap(storedFields)
-    miniSearch._dirtCount = dirtCount || 0
-    miniSearch._index = new SearchableMap()
 
     for (const [shortId, id] of miniSearch._documentIds) {
       miniSearch._idToShortId.set(id, shortId)
@@ -1572,32 +1557,17 @@ export default class MiniSearch<T = any> {
   static async loadJSAsync<T = any> (js: AsPlainObject, options: Options<T>): Promise<MiniSearch<T>> {
     const {
       index,
-      documentCount,
-      nextId,
       documentIds,
-      fieldIds,
       fieldLength,
-      averageFieldLength,
       storedFields,
-      dirtCount,
       serializationVersion
     } = js
-    if (serializationVersion !== 1 && serializationVersion !== 2) {
-      throw new Error('MiniSearch: cannot deserialize an index created with an incompatible version')
-    }
 
-    const miniSearch = new MiniSearch(options)
+    const miniSearch = this.instantiateMiniSearch(js, options)
 
-    miniSearch._documentCount = documentCount
-    miniSearch._nextId = nextId
     miniSearch._documentIds = await objectToNumericMapAsync(documentIds)
-    miniSearch._idToShortId = new Map<any, number>()
-    miniSearch._fieldIds = fieldIds
     miniSearch._fieldLength = await objectToNumericMapAsync(fieldLength)
-    miniSearch._avgFieldLength = averageFieldLength
     miniSearch._storedFields = await objectToNumericMapAsync(storedFields)
-    miniSearch._dirtCount = dirtCount || 0
-    miniSearch._index = new SearchableMap()
 
     for (const [shortId, id] of miniSearch._documentIds) {
       miniSearch._idToShortId.set(id, shortId)
@@ -1621,6 +1591,36 @@ export default class MiniSearch<T = any> {
       if (++count % 1000 === 0) await wait(0)
       miniSearch._index.set(term, dataMap)
     }
+
+    return miniSearch
+  }
+
+  /**
+   * @ignore
+   */
+  private static instantiateMiniSearch<T = any> (js: AsPlainObject, options: Options<T>): MiniSearch<T> {
+    const {
+      documentCount,
+      nextId,
+      fieldIds,
+      averageFieldLength,
+      dirtCount,
+      serializationVersion
+    } = js
+
+    if (serializationVersion !== 1 && serializationVersion !== 2) {
+      throw new Error('MiniSearch: cannot deserialize an index created with an incompatible version')
+    }
+
+    const miniSearch = new MiniSearch(options)
+
+    miniSearch._documentCount = documentCount
+    miniSearch._nextId = nextId
+    miniSearch._idToShortId = new Map<any, number>()
+    miniSearch._fieldIds = fieldIds
+    miniSearch._avgFieldLength = averageFieldLength
+    miniSearch._dirtCount = dirtCount || 0
+    miniSearch._index = new SearchableMap()
 
     return miniSearch
   }

--- a/src/SearchableMap/SearchableMap.ts
+++ b/src/SearchableMap/SearchableMap.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-labels */
 import { TreeIterator, ENTRIES, KEYS, VALUES, LEAF } from './TreeIterator'
-import fuzzySearch, { FuzzyResults } from './fuzzySearch'
-import { RadixTree, Entry, Path } from './types'
+import fuzzySearch, { type FuzzyResults } from './fuzzySearch'
+import type { RadixTree, Entry, Path } from './types'
 
 /**
  * A class implementing the same interface as a standard JavaScript

--- a/src/SearchableMap/TreeIterator.ts
+++ b/src/SearchableMap/TreeIterator.ts
@@ -1,4 +1,4 @@
-import { RadixTree, Entry, LeafType } from './types'
+import type { RadixTree, Entry, LeafType } from './types'
 
 /** @ignore */
 const ENTRIES = 'ENTRIES'

--- a/src/SearchableMap/fuzzySearch.ts
+++ b/src/SearchableMap/fuzzySearch.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-labels */
 import { LEAF } from './TreeIterator'
-import { RadixTree } from './types'
+import type { RadixTree } from './types'
 
 export type FuzzyResult<T> = [T, number]
 


### PR DESCRIPTION
- Added `.loadJSONAsync()` and `.loadJSAsync()` that are counterparts to their non-async version
- Added a simple test to make sure that `.loadJSONAsync()` creates a MiniSearch instance that is identical to `.loadJSON()`
- Replaced a few `import` with `import type` because TypeScript wasn't happy when I imported the project as a local dependency

I tried to dedupe the code as much as possible. However, the several `await` calls in inner loops prevent to do this cleanly without reducing code readability.