### PR TITLE
Fix type definitions directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "unpkg": "./dist/umd/index.js",
   "jsdelivr": "./dist/umd/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/es/index.d.ts",
   "author": "Luca Ongaro",
   "homepage": "https://lucaong.github.io/minisearch/",
   "bugs": "https://github.com/lucaong/minisearch/issues",


### PR DESCRIPTION
Closes #269 
Fixed Incorrect TypeScript Types Path in `package.json`  
Previously, the path was pointing to a non-existent directory, which was leading to issues when trying to use the package in TypeScript projects.