### PR TITLE
Use latest NodeJS on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: 'latest'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: 'latest'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
The CI builds started failing on node `v22.5.0` likely due to https://github.com/nodejs/node/issues/53902

The NodeJS version on CI was therefore pinned to 21 in https://github.com/lucaong/minisearch/pull/272

This pull request goes back to using the latest NodeJS version, and should be merged to master once the issue with NodeJS `v22.5.0` noted above is fixed, and the build on this pull request finally succeeds.