### PR TITLE
Add search option to apply term boosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+  - Add `boostTerm` search option to apply a custom boosting factor to specific
+    terms in the query
+
 ## v7.0.2
 
   - [fix] Fix regression on tokenizer producing blank terms when multiple

--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1150,6 +1150,22 @@ describe('MiniSearch', () => {
       expect(results[0].score).toBeCloseTo(resultsWithoutBoost[0].score * boostFactor)
     })
 
+    it('boosts terms by calling boostTerm with normalized query term, term index in the query, and array of all query terms', () => {
+      const query = 'Commedia nova'
+      const boostFactors = {
+        commedia: 1.5,
+        nova: 1.1
+      }
+      const boostTerm = jest.fn((term, i, terms) => boostFactors[term])
+      const resultsWithoutBoost = ms.search(query)
+      const results = ms.search(query, { boostTerm })
+
+      expect(boostTerm).toHaveBeenCalledWith('commedia', 0, ['commedia', 'nova'])
+      expect(boostTerm).toHaveBeenCalledWith('nova', 1, ['commedia', 'nova'])
+      expect(results[0].score).toBeCloseTo(resultsWithoutBoost[0].score * boostFactors.commedia)
+      expect(results[1].score).toBeCloseTo(resultsWithoutBoost[1].score * boostFactors.nova)
+    })
+
     it('skips document if boostDocument returns a falsy value', () => {
       const query = 'vita'
       const boostDocument = jest.fn((id, term) => id === 3 ? null : 1)


### PR DESCRIPTION
Term boosting (giving greater or lower importance to specific query terms) was previously not supported. It was technically possible by using the `boostDocument` search option (as shown here: https://github.com/lucaong/minisearch/issues/268) but cumbersome and error prone.

This commit adds a new search option, `boostTerm`, which makes it a lot easier to apply term boosting. The option is a function that is invoked with each query term (as normalized by `processTerm`), as well as the term index in the query, and the array of all query terms, and is expected to return a numeric boost factor.

A factor greater than 1 increases the importance of a term for the relevance scoring, a factor less than 1 decreases the importance of a term, and a factor equal to 1 is neutral.

## Examples

Boosting specific terms:

```js
const boostFactors = {
  'motorcycle': 1.2,
  'foo': 0.7
}

miniSearch.search('Motorcycle Maintenance', {
  boostTerm: (term) => boostFactors[term] || 1
})
```

Boosting the first few terms in the query:

```js
const boostFactors = [1.5, 1.2]

miniSearch.search('Motorcycle Maintenance', {
  boostTerm: (term, i) => boostFactors[i] || 1
})
```