### PR TITLE
Listen to global filter

### DIFF
--- a/src/MiniSearch.test.js
+++ b/src/MiniSearch.test.js
@@ -1211,6 +1211,21 @@ describe('MiniSearch', () => {
       expect(results.every(({ category }) => category === 'poetry')).toBe(true)
     })
 
+    it('allows to define a default filter upon instantiation', () => {
+      const ms = new MiniSearch({
+        fields: ['title', 'text'],
+        storeFields: ['category'],
+        searchOptions: {
+          filter: ({ category }) => category === 'poetry'
+        }
+      })
+      ms.addAll(documents)
+    
+      const results = ms.search('del')
+      expect(results.length).toBe(1)
+      expect(results.every(({ category }) => category === 'poetry')).toBe(true)
+    })
+
     it('allows customizing BM25+ parameters', () => {
       const ms = new MiniSearch({ fields: ['text'], searchOptions: { bm25: { k: 1.2, b: 0.7, d: 0.5 } } })
       const documents = [
@@ -1801,6 +1816,8 @@ e forse del mio dir poco ti cale`
       expect(results[0].suggestion).toEqual('quella')
       expect(results).toHaveLength(1)
     })
+
+
 
     it('respects the custom defaults set in the constructor', () => {
       const ms = new MiniSearch({

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1344,7 +1344,9 @@ export default class MiniSearch<T = any> {
       }
 
       Object.assign(result, this._storedFields.get(docId))
-      if (searchOptions.filter == null || searchOptions.filter(result)) {
+      const { searchOptions: globalSearchOptions } = this._options
+      const options = { ...globalSearchOptions, ...searchOptions }
+      if (options.filter == null || options.filter(result)) {
         results.push(result)
       }
     }
@@ -1352,8 +1354,7 @@ export default class MiniSearch<T = any> {
     // If it's a wildcard query, and no document boost is applied, skip sorting
     // the results, as all results have the same score of 1
     if (query === MiniSearch.wildcard &&
-      searchOptions.boostDocument == null &&
-      this._options.searchOptions.boostDocument == null) {
+      options.boostDocument == null) {
       return results
     }
 

--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -1325,6 +1325,9 @@ export default class MiniSearch<T = any> {
    * @param options  Search options. Each option, if not given, defaults to the corresponding value of `searchOptions` given to the constructor, or to the library default.
    */
   search (query: Query, searchOptions: SearchOptions = {}): SearchResult[] {
+    const { searchOptions: globalSearchOptions } = this._options
+    const options = { ...globalSearchOptions, ...searchOptions }
+
     const rawResults = this.executeQuery(query, searchOptions)
     const results = []
 
@@ -1344,8 +1347,6 @@ export default class MiniSearch<T = any> {
       }
 
       Object.assign(result, this._storedFields.get(docId))
-      const { searchOptions: globalSearchOptions } = this._options
-      const options = { ...globalSearchOptions, ...searchOptions }
       if (options.filter == null || options.filter(result)) {
         results.push(result)
       }


### PR DESCRIPTION
the filter function isn't actually being listened to unless it is directly passed to the search function.

This PR updates that, to listen to the global filter function unless it is overwritten in the searchOptions passed to the function.