### PR TITLE
Specify ES2018 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+  - [fix] Correctly specify that MiniSearch targets ES9 (ES2018), not ES6
+    (ES2015), due to the use of Unicode character class escapes in the
+    tokenizer RegExp. Note: the README explains how to achieve ES2015
+    compatibility.
+
 ## v7.1.1
 
   - [fix] Fix ability to pass the default `filter` search option in the

--- a/README.md
+++ b/README.md
@@ -330,9 +330,13 @@ for details about configuration options and methods.
 
 ## Browser and Node compatibility
 
-`MiniSearch` supports all browsers and NodeJS versions implementing the ES6
-(ES2015) JavaScript standard. That includes all modern browsers and NodeJS
+`MiniSearch` supports all browsers and NodeJS versions implementing the ES9
+(ES2018) JavaScript standard. That includes all modern browsers and NodeJS
 versions.
+
+ES6 (ES2015) compatibility can be achieved by transpiling the tokenizer RegExp
+to expand Unicode character class escapes, for example with
+https://babeljs.io/docs/babel-plugin-transform-unicode-sets-regex.
 
 ## Contributing
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "ESNext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */


### PR DESCRIPTION
The tokenizer RegExp uses UNicode character class escapes, which is part of ES2018, not ES2015.

See https://github.com/lucaong/minisearch/issues/286