### PR TITLE
fix(types): allow partial `weights` object

### DIFF
--- a/src/MiniSearch.ts
+++ b/src/MiniSearch.ts
@@ -49,7 +49,16 @@ export type SearchOptions = {
    * Relative weights to assign to prefix search results and fuzzy search
    * results. Exact matches are assigned a weight of 1.
    */
-  weights?: { fuzzy: number, prefix: number },
+  weights?: {
+    /**
+     * @default 0.45
+     */
+    fuzzy?: number
+    /**
+     * @default 0.375
+     */
+    prefix?: number
+  },
 
   /**
    * Function to calculate a boost factor for documents. It takes as arguments
@@ -1697,7 +1706,10 @@ export default class MiniSearch<T = any> {
       bm25: bm25params
     } = options
 
-    const { fuzzy: fuzzyWeight, prefix: prefixWeight } = { ...defaultSearchOptions.weights, ...weights }
+    const {
+      fuzzy: fuzzyWeight = defaultSearchOptions.weights.fuzzy,
+      prefix: prefixWeight = defaultSearchOptions.weights.prefix
+    } = weights || {}
 
     const data = this._index.get(query.term)
     const results = this.termResults(query.term, query.term, 1, query.termBoost, data, boosts, boostDocument, bm25params)


### PR DESCRIPTION
This fixes the type of `SearchOptions.weights` to allow partial definition.

I also added `@default` comments for each weight type, to give users a baseline value to tweak in experiments.

Finally, I changed how the default weights are merged into the user-provided weights, ensuring that an explicit `undefined` value in the user-provided weights doesn‘t prevent the default weight from being used.
