### PR TITLE
Relax the return type of extractField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 `MiniSearch` follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+  - [fix] Relax the return type of `extractField` to allow non-string values
+    (when a field is stored but not indexed, it can be any type)
+  - Add `stringifyField` option to customize how field values are turned into strings
+    for indexing
+
 ## v7.1.2
 
   - [fix] Correctly specify that MiniSearch targets ES9 (ES2018), not ES6


### PR DESCRIPTION
Resolves: https://github.com/lucaong/minisearch/issues/302

The return type of `extractField` should be `any` instead of `string`, because only indexed fields need to be strings, while fields that are saved but not indexed can be any object.

In order to maintain type safety for indexed fields, and to allow more customization options, this also adds a new `stringifyField` option to control how field values are turned into strings before indexing/de-indexing.